### PR TITLE
update script eggs-install.sh

### DIFF
--- a/isobuilder/eggs/eggs-install+.sh
+++ b/isobuilder/eggs/eggs-install+.sh
@@ -14,52 +14,26 @@ sudo apt-get install -f -y
 wget https://bit.ly/3tJuZ5R -O apps-educaandos
 chmod +x apps-educaandos
 ./apps-educaandos
-./apps-educaandos
 
-#copiar configuración para la ISO
-sudo cp -r /home/$USER/guadalinex/isobuilder/eggs/educaandos /usr/lib/penguins-eggs/addons/
+#instalar calamares (and configure it to act without root)
+sudo eggs calamares --install
 
-#instalar calamares
-#sudo eggs calamares
-sudo apt-get update -y
-sudo eggs calamares --install --theme educaandos
-
-#eliminar archivos innecesarios de EGGS
-sudo rm /usr/share/applications/calamares.desktop
-sudo rm /usr/lib/penguins-eggs/assets/penguins-eggs.desktop
-sudo rm /usr/lib/penguins-eggs/assets/penguins-links-add.desktop
-
-# paquetes necesarios para instalación en EFI secureboot
-##sudo dpkg -i grub-efi-amd64-signed*amd64.deb
-#sudo apt-get install grub-efi-amd64-signed -y 
-sudo apt update -y 
+# I usually use: sudo apt-get install grub-efi-amd64-bin
 sudo apt-get install shim-signed -y
-
-# Tenemos que modificar el archivo eggs.yaml a mano e incluir el vmlinuz y initrd con la versión, no dejar sin la versión.
-# así como los lenguajes, Europe/Madrid para la hora. Usar # sudo nano /etc/penguins-eggs.d/eggs.yaml después de estos dos comandos.
-sudo eggs dad -d
-sudo eggs dad
-
 
 # Modificar los grupos que instalará calamares al nuevo usuario
 sudo cp /home/$USER/guadalinex/isobuilder/eggs/educaandos/theme/calamares/modules/users.yml /usr/lib/penguins-eggs/conf/distros/focal/calamares/modules/users.yml
-sudo cp /home/$USER/guadalinex/isobuilder/eggs/educaandos/theme/calamares/modules/users.yml /etc/calamares/modules
 
+# NOW, we configure eggs, whit it's default 
+sudo eggs dad -d
 
-#sudo cp eggs.yaml /etc/penguins-eggs.d/
-#sudo cp exclude.list /usr/local/share/penguins-eggs/exclude.list
+# Tenemos que modificar el archivo eggs.yaml a mano e incluir el vmlinuz y initrd con la versión, no dejar sin la versión.
+# así como los lenguajes, Europe/Madrid para la hora. Usar # sudo nano /etc/penguins-eggs.d/eggs.yaml después de estos dos comandos.
+sudo nano /etc/penguins-eggs.d/eggs.yaml
 
-# instala lo necesario para la iso y borra scripts de creación de iso
-sudo eggs produce --fast --theme educaandos
-sudo eggs kill
+# iso creation fast
+# For developer version:
+# sudo eggs produce --fast --theme educaandos 
 
-# Con el siguiente comando le decimos que si a instalar calamares
-sudo eggs config
-sudo eggs status
-
-#Eliminar repositorio ubuntu
-sudo rm /etc/apt/sources.list.d/focal.list
-sudo apt-get update -y
-
-#crear iso definitiva
-sudo eggs produce -v --theme educaandos
+# crear iso definitiva
+# sudo eggs produce --max --theme educaandos --release


### PR DESCRIPTION
I think your script in this way is better.

Run in once and after just use eggs commands.

I think for your system to use --release flag in produce for the release. In that way on the installed system will be removed both calamares and eggs. 
